### PR TITLE
set locale explicitly in failing component test

### DIFF
--- a/src/lib/layout/HeaderBottomNav.spec.js
+++ b/src/lib/layout/HeaderBottomNav.spec.js
@@ -1,5 +1,6 @@
 import HeaderBottomNav from './HeaderBottomNav.svelte';
 import {render, screen} from '@testing-library/svelte';
+import {locale} from '$lib/stores/i18n';
 
 describe('Nav should have dropdown sub menus', () => {
   const navItems = [
@@ -15,7 +16,9 @@ describe('Nav should have dropdown sub menus', () => {
     },
   ];
 
-  test('toogles on message event', () => {
+  test('main navigations present present', () => {
+    locale.set('de');
+
     render(HeaderBottomNav, {props: {bot_nav: navItems}});
 
     // Relies on a lot of configuration wrt. translations, meaning


### PR DESCRIPTION
@jstet fixes the issue with the test. The problem was that the default from `locale` store was removed and when testing components in isolation nothing sets the `locale` in the background (compared to normal website launch). For the problematic test (and future tests) I've set the locale explicitly in the test instructions, although we can move it to the overall test setup if it becomes too repetitive.