### PR TITLE
added rest path  parameters and error pages for static build

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -78,7 +78,8 @@
     return parsedContent;
   }
 
-  // Setting page title by retreiving translations from translations and conditionally taking into account dynamic pages by using the page title attribute from the page data,
+  // Setting page title by retreiving translations from translations and conditionally taking
+  // into account dynamic pages by using the page title attribute from the page data,
   // assigned in the dynamic pages +page.server
   let title;
   let title_content;
@@ -104,7 +105,8 @@
   {#if $header_height}
     <div class="block xl:hidden" style="min-height: {$header_height}px;" />
     <div id="grow" class="w-screen">
-      {#if content}
+      <!-- page.error case is required for the static build which otherwise renders content -->
+      {#if content && $page.error == null}
         {#each content as section}
           {#if section.collection === 'heros'}
             <div class:mb-12={section.sort !== content.length}>
@@ -162,7 +164,8 @@
             </div>
           {/if}
         {/each}
-        <!-- if collection doesnt contain a custom section, load page anyways (but must be empty in this case) to write page key to store -->
+        <!-- if collection doesnt contain a custom section, load page anyways (but must be empty
+        in this case) to write page key to store -->
         {#if !content.find((e) => e.collection === 'custom_sections')}
           <slot />
         {/if}

--- a/src/routes/[[locale=locale]]/+error.svelte
+++ b/src/routes/[[locale=locale]]/+error.svelte
@@ -1,0 +1,12 @@
+<script>
+  import {page} from '$app/stores';
+  import {locale} from '$lib/stores/i18n';
+
+  $: errorMsg =
+    $locale === 'de' ? 'Es ist ein Fehler aufgetreten' : 'An error occurred';
+  console.error($page.error);
+</script>
+
+<div class="mx-auto my-52 w-fit text-3xl font-bold">
+  <h1>{errorMsg} &#x1F615;</h1>
+</div>

--- a/src/routes/[[locale=locale]]/[...catchall]/+page.js
+++ b/src/routes/[[locale=locale]]/[...catchall]/+page.js
@@ -1,0 +1,8 @@
+import {error} from '@sveltejs/kit';
+
+export const prerender = false;
+
+/** @type {import('./$types').PageLoad} */
+export function load(event) {
+  throw error(404, 'Not Found');
+}

--- a/src/routes/[[locale=locale]]/[events=events]/+error.svelte
+++ b/src/routes/[[locale=locale]]/[events=events]/+error.svelte
@@ -1,0 +1,11 @@
+<script>
+  import {page} from '$app/stores';
+  import {locale} from '$lib/stores/i18n';
+
+  $: errorMsg = $locale === 'de' ? 'Fehler bei Veranstaltungen' : 'Event error';
+  console.error($page.error);
+</script>
+
+<div class="mx-auto my-52 w-fit text-3xl font-bold">
+  <h1>{errorMsg} &#x1F615;</h1>
+</div>

--- a/src/routes/[[locale=locale]]/[events=events]/[...catch_events]/+page.js
+++ b/src/routes/[[locale=locale]]/[events=events]/[...catch_events]/+page.js
@@ -1,0 +1,8 @@
+import {error} from '@sveltejs/kit';
+
+export const prerender = false;
+
+/** @type {import('./$types').PageLoad} */
+export function load(event) {
+  throw error(404, 'Event not found');
+}

--- a/src/routes/[[locale=locale]]/[events=events]/[slug]/+page.server.js
+++ b/src/routes/[[locale=locale]]/[events=events]/[slug]/+page.server.js
@@ -1,6 +1,9 @@
 import directus_fetch from '$lib/js/directus_fetch';
 import {get_lang} from '$lib/js/helpers';
 import {eventDetailQuery} from './queries.js';
+import {error} from '@sveltejs/kit';
+import {locale} from '$lib/stores/i18n';
+import {get} from 'svelte/store';
 
 /** @type {import('./$types').PageServerLoad} */
 export async function load({params}) {
@@ -8,6 +11,16 @@ export async function load({params}) {
     slug: params.slug,
     language: get_lang(params),
   });
+
+  if (data.Events.length === 0) {
+    let errorMsg;
+    if (get(locale) === 'de') {
+      errorMsg = `Veranstaltung ${params.slug} nicht bekannt`;
+    } else {
+      errorMsg = `Event ${params.slug} not known.`;
+    }
+    throw error(404, errorMsg);
+  }
 
   return {event: data.Events[0]};
 }

--- a/src/routes/[[locale=locale]]/[using_data=using_data]/[projects=projects]/+error.svelte
+++ b/src/routes/[[locale=locale]]/[using_data=using_data]/[projects=projects]/+error.svelte
@@ -1,0 +1,11 @@
+<script>
+  import {page} from '$app/stores';
+  import {locale} from '$lib/stores/i18n';
+
+  $: errorMsg = $locale === 'de' ? 'Fehler bei Projekten' : 'Project error';
+  console.error($page.error);
+</script>
+
+<div class="mx-auto my-52 w-fit text-3xl font-bold">
+  <h1>{errorMsg} &#x1F615;</h1>
+</div>

--- a/src/routes/[[locale=locale]]/[using_data=using_data]/[projects=projects]/[...catch_projects]/+page.js
+++ b/src/routes/[[locale=locale]]/[using_data=using_data]/[projects=projects]/[...catch_projects]/+page.js
@@ -1,0 +1,8 @@
+import {error} from '@sveltejs/kit';
+
+export const prerender = false;
+
+/** @type {import('./$types').PageLoad} */
+export function load(event) {
+  throw error(404, 'Project not found');
+}

--- a/src/routes/[[locale=locale]]/[using_data=using_data]/[projects=projects]/[slug]/+page.server.js
+++ b/src/routes/[[locale=locale]]/[using_data=using_data]/[projects=projects]/[slug]/+page.server.js
@@ -3,6 +3,9 @@ import {get_lang} from '$lib/js/helpers';
 import _ from 'lodash';
 import {projectDetailsQuery} from './queries.js';
 import {handle_lang} from '$lib/js/helpers';
+import {get} from 'svelte/store';
+import {locale} from '$lib/stores/i18n';
+import {error} from '@sveltejs/kit';
 
 /** @type {import('./$types').PageLoad} */
 export async function load({params}) {
@@ -10,6 +13,16 @@ export async function load({params}) {
     slug: params.slug,
     language: get_lang(params),
   });
+
+  if (data.Projects.length === 0) {
+    let errorMsg;
+    if (get(locale) === 'de') {
+      errorMsg = `Projekt ${params.slug} nicht bekannt`;
+    } else {
+      errorMsg = `Project ${params.slug} not known.`;
+    }
+    throw error(404, errorMsg);
+  }
 
   const posts = handle_lang(
     _.flatMap(data.Projects[0].Posts, (data) => [data.Posts_id]),

--- a/src/routes/[[locale=locale]]/blog/+error.svelte
+++ b/src/routes/[[locale=locale]]/blog/+error.svelte
@@ -1,0 +1,11 @@
+<script>
+  import {page} from '$app/stores';
+  import {locale} from '$lib/stores/i18n';
+
+  $: errorMsg = $locale === 'de' ? 'Blog Post Fehler' : 'Blog post error';
+  console.error($page.error);
+</script>
+
+<div class="mx-auto my-52 w-fit text-3xl font-bold">
+  <h1>{errorMsg} &#x1F615;</h1>
+</div>

--- a/src/routes/[[locale=locale]]/blog/[...catch_posts]/+page.js
+++ b/src/routes/[[locale=locale]]/blog/[...catch_posts]/+page.js
@@ -1,0 +1,8 @@
+import {error} from '@sveltejs/kit';
+
+export const prerender = false;
+
+/** @type {import('./$types').PageLoad} */
+export function load(event) {
+  throw error(404, 'Blog post not found');
+}

--- a/src/routes/[[locale=locale]]/blog/[slug]/+page.server.js
+++ b/src/routes/[[locale=locale]]/blog/[slug]/+page.server.js
@@ -1,7 +1,10 @@
 import directus_fetch from '$lib/js/directus_fetch';
+import {locale} from '$lib/stores/i18n';
+import {get} from 'svelte/store';
 import {get_lang} from '$lib/js/helpers';
 import _ from 'lodash';
 import {blogPostQuery} from './queries.js';
+import {error} from '@sveltejs/kit';
 
 /** @type {import('./$types').PageLoad} */
 export async function load({params}) {
@@ -10,6 +13,17 @@ export async function load({params}) {
     language: get_lang(params),
   };
   const data = await directus_fetch(blogPostQuery, vars);
+
+  if (data.Posts.length === 0) {
+    let errorMsg;
+    if (get(locale) === 'de') {
+      errorMsg = `Blogpost ${params.slug} nicht bekannt`;
+    } else {
+      errorMsg = `Blog post ${params.slug} not known.`;
+    }
+    throw error(404, errorMsg);
+  }
+
   // checking if post exists in current locale, if not using other language
   let lang_content = _.find(
     data.Posts[0].translations,

--- a/src/routes/[[locale=locale]]/community/correlaidx/+error.svelte
+++ b/src/routes/[[locale=locale]]/community/correlaidx/+error.svelte
@@ -1,0 +1,12 @@
+<script>
+  import {page} from '$app/stores';
+  import {locale} from '$lib/stores/i18n';
+
+  $: errorMsg =
+    $locale === 'de' ? 'Fehler bei Local Chapter' : 'Local Chapter error';
+  console.error($page.error);
+</script>
+
+<div class="mx-auto my-52 w-fit text-3xl font-bold">
+  <h1>{errorMsg} &#x1F615;</h1>
+</div>

--- a/src/routes/[[locale=locale]]/community/correlaidx/[...catch_lcs]/+page.js
+++ b/src/routes/[[locale=locale]]/community/correlaidx/[...catch_lcs]/+page.js
@@ -1,0 +1,8 @@
+import {error} from '@sveltejs/kit';
+
+export const prerender = false;
+
+/** @type {import('./$types').PageLoad} */
+export function load(event) {
+  throw error(404, 'Local chapter not found');
+}

--- a/src/routes/[[locale=locale]]/community/correlaidx/[slug]/+page.server.js
+++ b/src/routes/[[locale=locale]]/community/correlaidx/[slug]/+page.server.js
@@ -1,6 +1,9 @@
 import directus_fetch from '$lib/js/directus_fetch';
 import {get_lang} from '$lib/js/helpers';
 import {lcDetailsQuery} from './queries.js';
+import {get} from 'svelte/store';
+import {locale} from '$lib/stores/i18n';
+import {error} from '@sveltejs/kit';
 
 /** @type {import('./$types').PageLoad} */
 export async function load({params}) {
@@ -8,6 +11,16 @@ export async function load({params}) {
     slug: params.slug,
     language: get_lang(params),
   });
+
+  if (data.Local_Chapters.length === 0) {
+    let errorMsg;
+    if (get(locale) === 'de') {
+      errorMsg = `Local Chapter ${params.slug} nicht bekannt`;
+    } else {
+      errorMsg = `Local Chapter ${params.slug} not known.`;
+    }
+    throw error(404, errorMsg);
+  }
 
   return {
     local_chapter: data.Local_Chapters[0],

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -185,6 +185,7 @@ if (process.env.PUBLIC_PRERENDER === 'ALL') {
   await addLcRoutes(prerenderRoutes);
   await addProjectRoutes(prerenderRoutes);
   await addEventRoutes(prerenderRoutes);
+  prerenderRoutes.push('*');
 } else {
   prerenderRoutes.push('*');
 }
@@ -199,7 +200,7 @@ const config = {
             assets: '.svelte-kit/cloudflare',
             fallback: null,
             precompress: false,
-            strict: true,
+            strict: false,
           })
         : adapter({
             routes: {

--- a/tests/error-pages.spec.js
+++ b/tests/error-pages.spec.js
@@ -1,0 +1,111 @@
+import {test, expect} from '@playwright/test';
+
+test.describe('test error pages', () => {
+  test('test pages root', async ({page}) => {
+    await page.goto('http://localhost:5173/not-a-valid-path', {
+      waitUntil: 'networkidle',
+    });
+    await expect(page.locator('#grow')).toHaveText(/.*Fehler.*/, {
+      ignoreCase: true,
+    });
+
+    await page.goto('http://localhost:5173/en/not-a-valid-path', {
+      waitUntil: 'networkidle',
+    });
+    await expect(page.locator('#grow')).toHaveText(/.*error.*/, {
+      ignoreCase: true,
+    });
+  });
+
+  test('test pages blog', async ({page}) => {
+    await page.goto('http://localhost:5173/blog/not-a-valid-post', {
+      waitUntil: 'networkidle',
+    });
+    await expect(page.locator('#grow')).toHaveText(/.*Fehler.*/, {
+      ignoreCase: true,
+    });
+    await expect(page.locator('#grow')).toHaveText(/.*Blog.*/, {
+      ignoreCase: true,
+    });
+
+    await page.goto('http://localhost:5173/en/blog/not-a-valid-post', {
+      waitUntil: 'networkidle',
+    });
+    await expect(page.locator('#grow')).toHaveText(/.*Blog.*/, {
+      ignoreCase: true,
+    });
+    await expect(page.locator('#grow')).toHaveText(/.*error.*/, {
+      ignoreCase: true,
+    });
+  });
+
+  test('test pages events', async ({page}) => {
+    await page.goto('http://localhost:5173/veranstaltungen/not-a-valid-event', {
+      waitUntil: 'networkidle',
+    });
+    await expect(page.locator('#grow')).toHaveText(/.*Fehler.*/, {
+      ignoreCase: true,
+    });
+    await expect(page.locator('#grow')).toHaveText(/.*Veranstaltung.*/, {
+      ignoreCase: true,
+    });
+
+    await page.goto('http://localhost:5173/en/events/not-a-valid-event', {
+      waitUntil: 'networkidle',
+    });
+    await expect(page.locator('#grow')).toHaveText(/.*event.*/, {
+      ignoreCase: true,
+    });
+    await expect(page.locator('#grow')).toHaveText(/.*error.*/, {
+      ignoreCase: true,
+    });
+  });
+
+  test('test pages projects', async ({page}) => {
+    await page.goto(
+      'http://localhost:5173/daten_nutzen/projekte/not-a-valid-project',
+      {waitUntil: 'networkidle'},
+    );
+    await expect(page.locator('#grow')).toHaveText(/.*Fehler.*/, {
+      ignoreCase: true,
+    });
+    await expect(page.locator('#grow')).toHaveText(/.*Projekt.*/, {
+      ignoreCase: true,
+    });
+
+    await page.goto(
+      'http://localhost:5173/en/using_data/projects/not-a-valid-project',
+      {waitUntil: 'networkidle'},
+    );
+    await expect(page.locator('#grow')).toHaveText(/.*project.*/, {
+      ignoreCase: true,
+    });
+    await expect(page.locator('#grow')).toHaveText(/.*error.*/, {
+      ignoreCase: true,
+    });
+  });
+
+  test('test pages correlaidx', async ({page}) => {
+    await page.goto(
+      'http://localhost:5173/community/correlaidx/not-a-valid-lc',
+      {waitUntil: 'networkidle'},
+    );
+    await expect(page.locator('#grow')).toHaveText(/.*local chapter.*/, {
+      ignoreCase: true,
+    });
+    await expect(page.locator('#grow')).toHaveText(/.*fehler.*/, {
+      ignoreCase: true,
+    });
+
+    await page.goto(
+      'http://localhost:5173/en/community/correlaidx/not-a-valid-lc',
+      {waitUntil: 'networkidle'},
+    );
+    await expect(page.locator('#grow')).toHaveText(/.*local chapter.*/, {
+      ignoreCase: true,
+    });
+    await expect(page.locator('#grow')).toHaveText(/.*error.*/, {
+      ignoreCase: true,
+    });
+  });
+});

--- a/tests/nav-menu.spec.js
+++ b/tests/nav-menu.spec.js
@@ -3,7 +3,7 @@ import {test, expect} from '@playwright/test';
 test.describe('test regular viewport', () => {
   test('test english button', async ({page}) => {
     await page.goto('http://localhost:5173/', {waitUntil: 'networkidle'});
-    await page.getByRole('button', {name: 'Language'}).click();
+    await page.getByRole('button', {name: 'Sprache wechseln'}).click();
     await page.getByRole('menuitem', {name: 'English'}).waitFor();
     await page.getByRole('menuitem', {name: 'English'}).click();
     await page.waitForNavigation({url: '**/en/'});


### PR DESCRIPTION
and the equivalent for the dynamic build

closes #304 and provides a first version for #23.

There are 5 different custom error pages for
- general routing errors
- invalid blog posts
- invalid events
- invalid projects
- invalid local chapters

Error messages are provided depending on the locale