### PR TITLE
Add meta description tag to HTML head

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -12,6 +12,10 @@
     <!-- 180×180 -->
     <link rel="manifest" href="%sveltekit.assets%/manifest.webmanifest" />
     <meta name="viewport" content="width=device-width" />
+    <meta
+      name="description"
+      content="CorrelAid is a Data4Good community of over 2400 data enthusiasts. With skilled volunteering and education, we empower civil society to use data for good"
+    />
     %sveltekit.head%
   </head>
 


### PR DESCRIPTION
fixes #336 

description is "CorrelAid is a Data4Good community of over 2400 data enthusiasts. With skilled volunteering and education, we empower civil society to use data for good"