### PR TITLE
included anonymized projects for project card overview

### DIFF
--- a/src/lib/components/ProjectsCard.svelte
+++ b/src/lib/components/ProjectsCard.svelte
@@ -3,11 +3,11 @@
   import ProjectLinks from '$lib/components/ProjectLinks.svelte';
   import {page} from '$app/stores';
   import {gen_lc_href} from '$lib/js/helpers';
-  import {t} from '$lib/stores/i18n';
+  import {t, locale} from '$lib/stores/i18n';
 
   export let title;
-  export let organization;
   export let subpage;
+  export let organization = void 0;
   export let summary = 'tbd';
   export let correlaidx = [];
   export let project_id = void 0;
@@ -15,6 +15,17 @@
   export let post_slug = void 0;
   export let podcast_href = void 0;
 
+  const annonymousOrg = typeof organization === 'undefined';
+
+  $: {
+    if (annonymousOrg) {
+      if ($locale === 'de') {
+        organization = 'Anonyme Organisation';
+      } else {
+        organization = 'Anonymous Organization';
+      }
+    }
+  }
   $: href = subpage
     ? $t('navbar.using_data.projects').url + '/' + project_id
     : null;
@@ -46,10 +57,7 @@
       {#each correlaidx as lc}
         <a
           class="text-medium mb-3 line-clamp-3 font-semibold text-base-content transition hover:text-primary"
-          href={gen_lc_href(
-            $page.params,
-            lc.Local_Chapters_id.translations[0].city,
-          )}>CorrelAidX {lc.Local_Chapters_id.translations[0].city}</a
+          href={gen_lc_href($page.params, lc)}>CorrelAidX {lc}</a
         >
       {/each}
     {/if}

--- a/src/lib/js/parse_cms_models/cards.js
+++ b/src/lib/js/parse_cms_models/cards.js
@@ -52,6 +52,8 @@ export function podcast_episodes(episode) {
 }
 
 export function projects(project) {
+  const status = project.status;
+
   const parsedProjectCard = {
     title: project.translations[0].title,
     organization:
@@ -68,7 +70,12 @@ export function projects(project) {
   }
 
   if (project.Local_Chapters.length > 0) {
-    parsedProjectCard['correlaidx'] = project.Local_Chapters;
+    parsedProjectCard['correlaidx'] = project.Local_Chapters.map((lc) => {
+      if (typeof lc.Local_Chapters_id.translations[0].city !== 'string') {
+        throw new Error('Local chapter name is missing or not a string');
+      }
+      return lc.Local_Chapters_id.translations[0].city;
+    });
   }
 
   if (project.Podcast) {
@@ -85,7 +92,26 @@ export function projects(project) {
     parsedProjectCard['repo'] = project.Projects_Outputs[0].url;
   }
 
-  return parsedProjectCard;
+  function anonymizeProjectCard(parsedProjectCard) {
+    const anonymizedProjectCard = {};
+
+    anonymizedProjectCard['title'] = parsedProjectCard['title'];
+    anonymizedProjectCard['subpage'] = parsedProjectCard['subpage'];
+
+    for (const field of ['summary', 'project_id', 'correlaidx']) {
+      if (field in parsedProjectCard) {
+        anonymizedProjectCard[field] = parsedProjectCard[field];
+      }
+    }
+
+    return anonymizedProjectCard;
+  }
+
+  if (status === 'published_anon') {
+    return anonymizeProjectCard(parsedProjectCard);
+  } else {
+    return parsedProjectCard;
+  }
 }
 
 export function lcProjects(lcProject) {
@@ -106,7 +132,12 @@ export function lcProjects(lcProject) {
   }
 
   if (project.Local_Chapters.length > 0) {
-    parsedProjectCard['correlaidx'] = project.Local_Chapters;
+    parsedProjectCard['correlaidx'] = project.Local_Chapters.map((lc) => {
+      if (typeof lc.Local_Chapters_id.translations[0].city !== 'string') {
+        throw new Error('Local chapter name is missing or not a string');
+      }
+      return lc.Local_Chapters_id.translations[0].city;
+    });
   }
 
   if (project.Podcast) {

--- a/src/lib/js/parse_cms_models/cards.spec.js
+++ b/src/lib/js/parse_cms_models/cards.spec.js
@@ -1,0 +1,91 @@
+import {projects} from './cards.js';
+
+describe('project card parsing and anonymization', () => {
+  const anonProject = {
+    status: 'published_anon',
+    subpage: false,
+    project_id: 'Some project id',
+    Podcast: null,
+    Posts: [],
+    Projects_Outputs: [],
+    Organizations: [
+      {
+        Organizations_id: {
+          translations: [
+            {
+              languages_code: {
+                code: 'de-DE',
+              },
+              name: 'Non-public organization name',
+            },
+          ],
+        },
+      },
+    ],
+    translations: [
+      {
+        title: 'Public project title',
+        description: '',
+        summary: null,
+      },
+    ],
+    Local_Chapters: [],
+  };
+
+  const publishedProject = {
+    status: 'published',
+    subpage: false,
+    project_id: 'Another project id',
+    Podcast: null,
+    Posts: [],
+    Projects_Outputs: [],
+    Organizations: [
+      {
+        Organizations_id: {
+          translations: [
+            {
+              languages_code: {
+                code: 'de-DE',
+              },
+              name: 'Public organization name',
+            },
+          ],
+        },
+      },
+    ],
+    translations: [
+      {
+        title: 'Another public project title',
+        description: '',
+        summary: null,
+      },
+    ],
+    Local_Chapters: [],
+  };
+
+  test('parse anonymous', () => {
+    const parsedProjectCard = projects(anonProject);
+
+    expect(parsedProjectCard.organization).toBeUndefined();
+    expect(parsedProjectCard.title).toEqual('Public project title');
+    expect(parsedProjectCard.subpage).toEqual(false);
+  });
+
+  test('parse published', () => {
+    const parsedProjectCard = projects(publishedProject);
+
+    expect(parsedProjectCard.organization).toEqual('Public organization name');
+    expect(parsedProjectCard.title).toEqual('Another public project title');
+    expect(parsedProjectCard.subpage).toEqual(false);
+  });
+
+  test('parse anonymous with subpage', () => {
+    const anonProjectWithSubpage = {...anonProject, subpage: true};
+    const parsedProjectCard = projects(anonProjectWithSubpage);
+
+    expect(parsedProjectCard.organization).toBeUndefined();
+    expect(parsedProjectCard.title).toEqual('Public project title');
+    expect(parsedProjectCard.subpage).toEqual(true);
+    expect(parsedProjectCard.project_id).toEqual('Some project id');
+  });
+});

--- a/src/routes/[[locale=locale]]/[using_data=using_data]/[projects=projects]/+page.server.js
+++ b/src/routes/[[locale=locale]]/[using_data=using_data]/[projects=projects]/+page.server.js
@@ -22,5 +22,8 @@ export async function load({params}) {
     project.Posts = posts;
   }
 
-  return {projects: parseEntries(projects, 'projects')};
+  // Some projects are anonymized and contain sensitive data.
+  // In case of an error, we don't want to log the input, which is
+  // why we set logInputOnError to false.
+  return {projects: parseEntries(projects, 'projects', false)};
 }

--- a/src/routes/[[locale=locale]]/[using_data=using_data]/[projects=projects]/[slug]/+page.svelte
+++ b/src/routes/[[locale=locale]]/[using_data=using_data]/[projects=projects]/[slug]/+page.svelte
@@ -24,24 +24,23 @@
       {#each project.Local_Chapters as lc}
         <a
           class="text-medium mb-3 line-clamp-3 font-semibold text-base-content transition hover:text-primary"
-          href={gen_lc_href(
-            $page.params,
-            lc.Local_Chapters_id.translations[0].city,
-          )}>CorrelAidX {lc.Local_Chapters_id.translations[0].city}</a
+          href={gen_lc_href($page.params, lc)}>CorrelAidX {lc}</a
         >
       {/each}
     {/if}
     <div class="mb-5">
       <ProjectLinks {...project.projectLinks} />
     </div>
-    <Box>
-      <h2 class="text-xl font-semibold">
-        {project.organization_name}
-      </h2>
-      <p>
-        <Html source={project.organization_description} options={'!px-0'} />
-      </p>
-    </Box>
+    {#if project.organization}
+      <Box>
+        <h2 class="text-xl font-semibold">
+          {project.organization.name}
+        </h2>
+        <p>
+          <Html source={project.organization.description} options={'!px-0'} />
+        </p>
+      </Box>
+    {/if}
   </div>
 
   <Html source={project.description} options={'mx-auto'} slot="main" />

--- a/src/routes/[[locale=locale]]/[using_data=using_data]/[projects=projects]/queries.js
+++ b/src/routes/[[locale=locale]]/[using_data=using_data]/[projects=projects]/queries.js
@@ -1,6 +1,6 @@
 export const projectOverviewQuery = `
 query ProjectOverview($language: String = "de-DE") {
-	Projects(filter: { status: { _eq: "published" } }) {
+	Projects(filter: { status: { _in: ["published", "published_anon"] } }) {
 		status
 		subpage
 		project_id


### PR DESCRIPTION
relates to #469
and  #474

Log sanitation is done in its simplest form by omitting to log input objects when dealing with project card parsing altogether. This is the safest option, but also means that nothing is logged for errors regarding published projects.