### PR TITLE
added anonymous projects to lc pages

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+PUBLIC_API_URL="https://cms.correlaid.org"
+PUBLIC_ON_CMS_ERROR="FAIL"

--- a/src/lib/js/helpers.js
+++ b/src/lib/js/helpers.js
@@ -184,7 +184,7 @@ function extractLanguages(entry) {
  * Get translation translation with fallback.
  * The fallback is any other available translation.
  */
-function getTranslation(entry, currentLanguage) {
+export function getTranslation(entry, currentLanguage) {
   const translation = entry.translations.find(
     (translation) => translation.languages_code.code === currentLanguage,
   );

--- a/src/lib/js/parse_cms.js
+++ b/src/lib/js/parse_cms.js
@@ -47,11 +47,27 @@ export function parseContent(rawSections, page) {
   return parsedContent;
 }
 
-export function parseEntries(rawEntries, type, logInputOnError = true) {
+/**
+ * Parses an array of raw entries of a given type.
+ *
+ * @param {Array} rawEntries - Array of raw entries.
+ * @param {string} type - name of the function in parse_cms_models that should be used to parse
+ *  the entries.
+ * @param {boolean} logInputOnError - Flag whether the raw input should be logged in case of an error.
+ *  Defaults to true, but should be set to false for sensitive data.
+ * @param {Array} additionalParameters - Additional parameters that should be passed to the parsing
+ *  function via the spread operator.
+ */
+export function parseEntries(
+  rawEntries,
+  type,
+  logInputOnError = true,
+  additionalParameters = [],
+) {
   const parsedEntries = [];
   for (const rawEntry of rawEntries) {
     try {
-      const entry = parseModel[type](rawEntry);
+      const entry = parseModel[type](rawEntry, ...additionalParameters);
       parsedEntries.push(entry);
     } catch (err) {
       if (logInputOnError) {
@@ -165,7 +181,7 @@ export function anonymizeProject(parsedProject) {
   return anonymizedProject;
 }
 
-export function parseLocalChapterPage(localChapterPage) {
+export function parseLocalChapterPage(localChapterPage, params) {
   let parsedLcPage;
   try {
     parsedLcPage = {
@@ -174,6 +190,8 @@ export function parseLocalChapterPage(localChapterPage) {
       projects: parseEntries(
         localChapterPage.Local_Chapters[0].Projects,
         'lcProjects',
+        false,
+        [params],
       ),
     };
 

--- a/src/lib/js/parse_cms_models/cards.js
+++ b/src/lib/js/parse_cms_models/cards.js
@@ -1,4 +1,4 @@
-import {gen_img_url} from '../helpers.js';
+import {gen_img_url, getTranslation, get_lang} from '../helpers.js';
 import _ from 'lodash';
 import translations from '../../data/translations.js';
 
@@ -78,9 +78,37 @@ export function podcast_episodes(episode) {
   return parsedEpisode;
 }
 
-export function projects(project) {
-  const status = project.status;
+function anonymizeProjectCard(parsedProjectCard, lang) {
+  const anonymizedProjectCard = {};
 
+  anonymizedProjectCard['title'] = parsedProjectCard['title'];
+  anonymizedProjectCard['subpage'] = parsedProjectCard['subpage'];
+  if (lang === 'de-DE') {
+    anonymizedProjectCard['organization'] =
+      translations['de']['organization.anonymous'].text;
+  } else {
+    anonymizedProjectCard['organization'] =
+      translations['en']['organization.anonymous'].text;
+  }
+
+  // This is expected to be always False for anonymized projects
+  // as there should normally no reason to anonymize an internal projects.
+  // However, if we want to anonymize an internal project, we can have to
+  // explicitly overwrite this value because otherwise the different layout
+  // of internal projects would be used negating the anonymity
+  anonymizedProjectCard['isInternal'] = false;
+
+  for (const field of ['summary', 'project_id', 'correlaidx', 'type', 'data']) {
+    if (field in parsedProjectCard) {
+      anonymizedProjectCard[field] = parsedProjectCard[field];
+    }
+  }
+
+  return anonymizedProjectCard;
+}
+
+export function projects(project, params) {
+  const status = project.status;
   const lang = project.translations[0].languages_code.code;
 
   const parsedProjectCard = {
@@ -138,9 +166,11 @@ export function projects(project) {
     parsedProjectCard['podcast_href'] = project.Podcast.soundcloud_link;
   }
 
+  const currentLanguage = get_lang(params);
   for (const post of project.Posts) {
-    if (post.translations.slug) {
-      parsedProjectCard['post_slug'] = post.translations.slug;
+    const translation = getTranslation(post.Posts_id, currentLanguage);
+    if (translation.slug) {
+      parsedProjectCard['post_slug'] = translation.slug;
       break;
     }
   }
@@ -154,41 +184,6 @@ export function projects(project) {
     }
   }
 
-  function anonymizeProjectCard(parsedProjectCard, lang) {
-    const anonymizedProjectCard = {};
-
-    anonymizedProjectCard['title'] = parsedProjectCard['title'];
-    anonymizedProjectCard['subpage'] = parsedProjectCard['subpage'];
-    if (lang === 'de-DE') {
-      anonymizedProjectCard['organization'] =
-        translations['de']['organization.anonymous'].text;
-    } else {
-      anonymizedProjectCard['organization'] =
-        translations['en']['organization.anonymous'].text;
-    }
-
-    // This is expected to be always False for anonymized projects
-    // as there should normally no reason to anonymize an internal projects.
-    // However, if we want to anonymize an internal project, we can have to
-    // explicitly overwrite this value because otherwise the different layout
-    // of internal projects would be used negating the anonymity
-    anonymizedProjectCard['isInternal'] = false;
-
-    for (const field of [
-      'summary',
-      'project_id',
-      'correlaidx',
-      'type',
-      'data',
-    ]) {
-      if (field in parsedProjectCard) {
-        anonymizedProjectCard[field] = parsedProjectCard[field];
-      }
-    }
-
-    return anonymizedProjectCard;
-  }
-
   if (status === 'published_anon') {
     return anonymizeProjectCard(parsedProjectCard, lang);
   } else {
@@ -196,65 +191,8 @@ export function projects(project) {
   }
 }
 
-export function lcProjects(lcProject) {
-  const project = lcProject.Projects_id;
-
-  const parsedProjectCard = {
-    title: project.translations[0].title,
-    organization:
-      project.Organizations[0].Organizations_id.translations[0].name,
-    subpage: project.subpage,
-  };
-
-  if (project.translations[0].summary !== null) {
-    parsedProjectCard['summary'] = project.translations[0].summary;
-  }
-
-  if (project.subpage) {
-    parsedProjectCard['project_id'] = project.project_id;
-  }
-
-  if (project.Local_Chapters.length > 0) {
-    parsedProjectCard['correlaidx'] = project.Local_Chapters.map((lc) => {
-      if (typeof lc.Local_Chapters_id.translations[0].city !== 'string') {
-        throw new Error('Local chapter name is missing or not a string');
-      }
-      return lc.Local_Chapters_id.translations[0].city;
-    });
-  }
-
-  if (project.Podcast) {
-    parsedProjectCard['podcast_href'] = project.Podcast.soundcloud_link;
-  }
-  if (project.Posts.length > 0) {
-    if (project.Posts[0].Posts_id !== null) {
-      parsedProjectCard['post_slug'] =
-        project.Posts[0].Posts_id.translations[0].slug;
-    }
-  }
-  if (project.Projects_Outputs.length > 0) {
-    const repo = project.Projects_Outputs.find(
-      (obj) => obj.output_type === 'repository',
-    );
-    if (repo) {
-      parsedProjectCard['repo'] = repo.url;
-    }
-  }
-  if (project.translations[0].type) {
-    parsedProjectCard['type'] = project.translations[0]['type'].map((str) =>
-      str.replace('_', ' ').toLowerCase(),
-    );
-  }
-
-  if (project.translations[0].data) {
-    if (!_.isEmpty(project.translations[0].data)) {
-      parsedProjectCard['data'] = project.translations[0].data.map((str) =>
-        str.replace('_', ' ').toLowerCase(),
-      );
-    }
-  }
-
-  return parsedProjectCard;
+export function lcProjects(lcProject, params) {
+  return projects(lcProject.Projects_id, params);
 }
 
 export function workshops(workshop) {

--- a/src/lib/js/parse_cms_models/cards.spec.js
+++ b/src/lib/js/parse_cms_models/cards.spec.js
@@ -93,8 +93,12 @@ describe('project card parsing and anonymization', () => {
     Local_Chapters: [],
   };
 
+  const params = {
+    locale: 'de',
+  };
+
   test('parse anonymous', () => {
-    const parsedProjectCard = projects(anonProject);
+    const parsedProjectCard = projects(anonProject, params);
 
     expect(parsedProjectCard.organization).toEqual('Anonyme Organisation');
     expect(parsedProjectCard.title).toEqual('Public project title');
@@ -102,7 +106,7 @@ describe('project card parsing and anonymization', () => {
   });
 
   test('parse published', () => {
-    const parsedProjectCard = projects(publishedProject);
+    const parsedProjectCard = projects(publishedProject, params);
 
     expect(parsedProjectCard.organization).toEqual('Public organization name');
     expect(parsedProjectCard.title).toEqual('Another public project title');
@@ -111,7 +115,7 @@ describe('project card parsing and anonymization', () => {
 
   test('parse anonymous with subpage', () => {
     const anonProjectWithSubpage = {...anonProject, subpage: true};
-    const parsedProjectCard = projects(anonProjectWithSubpage);
+    const parsedProjectCard = projects(anonProjectWithSubpage, params);
 
     expect(parsedProjectCard.organization).toEqual('Anonyme Organisation');
     expect(parsedProjectCard.title).toEqual('Public project title');
@@ -120,7 +124,7 @@ describe('project card parsing and anonymization', () => {
   });
 
   test('parse internal project', () => {
-    const parsedProjectCard = projects(internalProject);
+    const parsedProjectCard = projects(internalProject, params);
     expect(parsedProjectCard.organization).toEqual('Internes Projekt');
     expect(parsedProjectCard.isInternal).toBeTruthy();
   });

--- a/src/routes/[[locale=locale]]/[using_data=using_data]/[project_database=project_database]/+page.server.js
+++ b/src/routes/[[locale=locale]]/[using_data=using_data]/[project_database=project_database]/+page.server.js
@@ -3,7 +3,6 @@ import {
   getAllowedStatus,
 } from '$lib/js/directus_fetch';
 import {get_lang} from '$lib/js/helpers';
-import {handle_lang} from '$lib/js/helpers';
 import {projectOverviewQuery} from './queries.js';
 import {parseEntries} from '$lib/js/parse_cms';
 
@@ -16,19 +15,8 @@ export async function load({params}) {
 
   const projects = data.Projects;
 
-  for (const project of projects) {
-    const posts = handle_lang(
-      project.Posts.map((data) => data.Posts_id).filter(
-        (data) => data !== null,
-      ),
-      params,
-    );
-
-    project.Posts = posts;
-  }
-
   // Some projects are anonymized and contain sensitive data.
   // In case of an error, we don't want to log the input, which is
   // why we set logInputOnError to false.
-  return {projects: parseEntries(projects, 'projects', false)};
+  return {projects: parseEntries(projects, 'projects', false, [params])};
 }

--- a/src/routes/[[locale=locale]]/community/correlaidx/[slug]/+page.server.js
+++ b/src/routes/[[locale=locale]]/community/correlaidx/[slug]/+page.server.js
@@ -1,5 +1,7 @@
-import directus_fetch from '$lib/js/directus_fetch';
-import {getAllowedStatus} from '$lib/js/directus_fetch.js';
+import {
+  directus_authorized_fetch,
+  getAllowedStatus,
+} from '$lib/js/directus_fetch';
 import {get_lang} from '$lib/js/helpers';
 import {lcDetailsQuery} from './queries.js';
 import {error} from '@sveltejs/kit';
@@ -35,7 +37,7 @@ function capitalizeInternal(string) {
 
 /** @type {import('./$types').PageLoad} */
 export async function load({params}) {
-  const data = await directus_fetch(lcDetailsQuery, {
+  const data = await directus_authorized_fetch(lcDetailsQuery, {
     slug: capitalize(params.slug),
     language: get_lang(params),
     status: getAllowedStatus(),
@@ -45,5 +47,5 @@ export async function load({params}) {
     throw error(404);
   }
 
-  return parseLocalChapterPage(data);
+  return parseLocalChapterPage(data, params);
 }

--- a/src/routes/[[locale=locale]]/community/correlaidx/[slug]/queries.js
+++ b/src/routes/[[locale=locale]]/community/correlaidx/[slug]/queries.js
@@ -28,7 +28,11 @@ query LocalChapterDetails($slug: String, $language: String = "de-DE", $status: [
 	}
 	Local_Chapters(filter: { translations: { city: { _eq: $slug } } }) {
 		Projects {
-			Projects_id {
+			Projects_id(
+				filter: { status: { _in: ["published", "published_anon"] } }
+			) {
+				status
+				is_internal
 				subpage
 				project_id
 				Podcast {
@@ -63,6 +67,9 @@ query LocalChapterDetails($slug: String, $language: String = "de-DE", $status: [
 					}
 				}
 				translations(filter: { languages_code: { code: { _eq: $language } } }) {
+					languages_code {
+						code
+					}
 					title
 					description
 					summary


### PR DESCRIPTION
closes #527

Also refactored `parseEntries` to allow for optional additional parameters to be passed on demand to parsing functions. This allows to move more CMS processing into the parsing logic and out of the `+page.server.js`, for instance by passing url `params` along.