### PR TITLE
Blog schema updates

### DIFF
--- a/src/lib/js/parse_cms.js
+++ b/src/lib/js/parse_cms.js
@@ -97,8 +97,8 @@ export function parseProject(project) {
     if (project.Podcast) {
       projectLinks['podcast_href'] = project.Podcast.soundcloud_link;
     }
-    if (project.Posts.length !== 0) {
-      projectLinks['post_slug'] = project.Posts[0].translations.slug;
+    if (project.Blog_Posts.length !== 0) {
+      projectLinks['post_slug'] = project.Blog_Posts[0].translations.slug;
     }
 
     const projectContacts = [];
@@ -246,13 +246,13 @@ export function parseBlogPostPage(blogPostPage) {
 
   try {
     parsedBlogPostPage = {
-      pubDate: blogPostPage.Posts[0].pubdate,
-      contentAllLanguages: blogPostPage.Posts[0].translations,
+      pubDate: blogPostPage.Blog_Posts[0].publication_datetime,
+      contentAllLanguages: blogPostPage.Blog_Posts[0].translations,
       content_creators: parseEntries(
-        blogPostPage.Posts[0].content_creators,
+        blogPostPage.Blog_Posts[0].content_creators,
         'content_creators',
       ),
-      post: blogPostPage.Posts[0],
+      post: blogPostPage.Blog_Posts[0],
     };
     if (typeof parsedBlogPostPage.contentAllLanguages === 'undefined') {
       throw new Error('Blog post does not contain content in any language');

--- a/src/lib/js/parse_cms_models/people.js
+++ b/src/lib/js/parse_cms_models/people.js
@@ -45,12 +45,11 @@ function persons(person) {
   // TODO: does not quite make sense in terms of naming, because it is used to
   // parse global admins directly
   const links = parsePersonLinks(person.person);
-
   const parsedPerson = {
     name: person.person.name,
     email: person.person.email,
-    position: person.translations[0].position,
-    description: person.translations[0].description,
+    position: person.person.translations[0].position,
+    description: person.person.translations[0].description,
     links: links,
   };
 

--- a/src/routes/[[locale=locale]]/blog/+page.server.js
+++ b/src/routes/[[locale=locale]]/blog/+page.server.js
@@ -14,9 +14,9 @@ export async function load({params}) {
 
   // console.log(data.Posts[0])
 
-  const posts = handle_lang(data.Posts, params);
+  const posts = handle_lang(data.Blog_Posts, params);
 
-  // console.log(posts[0])
+  //console.log(posts[0])
 
   return {posts: parseEntries(posts, 'blog_posts')};
 }

--- a/src/routes/[[locale=locale]]/blog/[slug]/+page.server.js
+++ b/src/routes/[[locale=locale]]/blog/[slug]/+page.server.js
@@ -14,7 +14,7 @@ export async function load({params}) {
   };
   const data = await directus_fetch(blogPostQuery, vars);
 
-  if (data.Posts.length === 0) {
+  if (data.Blog_Posts.length === 0) {
     throw error(404);
   }
 

--- a/src/routes/[[locale=locale]]/blog/[slug]/queries.js
+++ b/src/routes/[[locale=locale]]/blog/[slug]/queries.js
@@ -4,7 +4,7 @@ query BlogPostQuery(
 	$status: [String] = ["published"]
 	$language: String = "de-DE"
 ) {
-	Posts(
+	Blog_Posts(
 		filter: {
 			_and: [
 				{ translations: { slug: { _eq: $slug } } }
@@ -12,7 +12,7 @@ query BlogPostQuery(
 			]
 		}
 	) {
-		pubdate
+		publication_datetime
 		title_image {
 			id
 			description
@@ -28,6 +28,8 @@ query BlogPostQuery(
 						filter: { languages_code: { code: { _eq: $language } } }
 					) {
 						pronouns
+						description
+						position
 					}
 					website
 					twitter

--- a/src/routes/[[locale=locale]]/blog/queries.js
+++ b/src/routes/[[locale=locale]]/blog/queries.js
@@ -3,8 +3,8 @@ query BlogQuery(
 	$language: String = "de-DE"
 	$status: [String] = ["published"]
 ) {
-	Posts(sort: "-pubdate", filter: { status: { _in: $status } }) {
-		pubdate
+	Blog_Posts(sort: "-publication_datetime", filter: { status: { _in: $status } }) {
+		publication_datetime
 		title_image {
 			id
 			description


### PR DESCRIPTION
minor updates after recreating blog schema. 

- pubdate -> publication_datetime (align with podcast)
- collection is named Blog_Posts, not Posts (which was confusing for new people)

open questions  / issues: 

- [ ] i adapted the parsing of the person (people.js) because i (wrongly) added the description to the person itself and not to the content creator. Question: do we want to keep it? 
- [ ] date is currently shown to be "invalid" 
- [ ] the list of blog posts is full width even though i did not adapt any code of this (afaik)

As expressed before, I feel like most people in CorrelAid have "one description" and it's unnecessary complexity to have different descriptions for content creators, global admins, ... if we want to add this layer later, we still could?!